### PR TITLE
feat: add network wrapper for ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It simulates a minimal **proto-AGI architecture** by maintaining symbolic contin
 - Embeddings via `sentence-transformers` (local CPU or GPU)
 - Vector search via `scikit-learn`, `faiss`, or brute force (initially)
 - Motifs are serialized to `data/motifs.json`
-- Ollama CLI used for model inference (e.g. `llama2`, `mistral`, `gemma`)
+- Ollama CLI or HTTP API used for model inference (e.g. `llama2`, `mistral`, `gemma`)
 
 ---
 


### PR DESCRIPTION
## Summary
- extend `query_ollama` to optionally call a remote Ollama server over HTTP
- document CLI or HTTP API support for inference

## Testing
- `python -m py_compile symbolic-memory-core/core/ollama_interface.py symbolic-memory-core/threads/examples/justice_thread.py`


------
https://chatgpt.com/codex/tasks/task_b_68a12cdd5b608325b3bb241588928a39