### PR TITLE
Add novelty and confidence utilities

### DIFF
--- a/symbolic-memory-core/utils/confidence.py
+++ b/symbolic-memory-core/utils/confidence.py
@@ -1,0 +1,91 @@
+from typing import Dict, List
+import re
+from embeddings.embedder import embed_text, cosine_sparse
+from core.motif import SymbolicMemoryCore
+
+HEDGE_RE = re.compile(r"\b(might|maybe|perhaps|possibly|could|unclear|not sure|i think|it seems|appears)\b", re.I)
+
+def _text_quality(text: str) -> float:
+    """
+    0..1 where higher ~ clearer, less hedging/repetition, some structure.
+    Simple, fast, deterministic.
+    """
+    if not text or not text.strip():
+        return 0.0
+    t = text.strip()
+
+    # Hedging penalty
+    hedges = len(HEDGE_RE.findall(t))
+    hedge_pen = min(1.0, hedges / 8.0)  # cap
+
+    # Repetition penalty: repeated 3+ word shingles
+    words = [w.lower() for w in re.findall(r"[A-Za-z0-9_]+", t)]
+    rep_pen = 0.0
+    if len(words) >= 9:
+        shingles = [" ".join(words[i:i+3]) for i in range(len(words)-2)]
+        from collections import Counter
+        c = Counter(shingles)
+        repeats = sum(v-1 for v in c.values() if v > 1)
+        rep_pen = min(1.0, repeats / max(1, len(shingles)//5))
+
+    # Structure bonus: presence of bullets / numbering / headings
+    structure = 0.0
+    if any(line.strip().startswith(("-", "*", "•")) for line in t.splitlines()):
+        structure += 0.3
+    if re.search(r"^\s*\d+\.", t, re.M):
+        structure += 0.3
+    if len(t.splitlines()) >= 3:
+        structure += 0.2
+    structure = min(0.7, structure)
+
+    # Length reasonableness: very short or extremely long is suspicious
+    ln = len(words)
+    if ln < 30:
+        len_pen = 0.4
+    elif ln > 1200:
+        len_pen = 0.3
+    else:
+        len_pen = 0.0
+
+    # Base quality
+    q = 1.0 - (0.5*hedge_pen + 0.4*rep_pen + 0.3*len_pen)
+    q = max(0.0, min(1.0, q + structure))
+    return q
+
+def _context_density(smc: SymbolicMemoryCore, text: str, sim_k: int = 5) -> float:
+    """
+    0..1 indicating how well the text anchors in existing memory.
+    Uses max cosine similarity to any motif and count of near neighbors.
+    """
+    vec = embed_text(text)
+    if not smc.motifs or not vec:
+        return 0.0
+    sims: List[float] = []
+    for m in smc.list_motifs():
+        sims.append(cosine_sparse(vec, embed_text(m.content)))
+    sims.sort(reverse=True)
+    max_sim = sims[0] if sims else 0.0
+    near = [s for s in sims[:sim_k] if s >= 0.35]
+    density = 0.6*max_sim + 0.4*(len(near)/float(sim_k))
+    return max(0.0, min(1.0, density))
+
+def _self_rating_fn(prompt_text: str) -> float:
+    """
+    Placeholder for a model self-rating step (0..1).
+    Keep stub-safe by returning a neutral value; you can replace this by
+    calling your LLM with a rating prompt and parsing a number.
+    """
+    return 0.5
+
+def confidence_score(
+    smc: SymbolicMemoryCore,
+    generated_text: str,
+    use_self_rating: bool = False,
+    weights = {"text":0.45, "context":0.45, "self":0.10},
+) -> Dict[str, float]:
+    tq = _text_quality(generated_text)
+    cd = _context_density(smc, generated_text)
+    sr = _self_rating_fn(generated_text) if use_self_rating else 0.5  # neutral when off
+    score = weights["text"]*tq + weights["context"]*cd + weights["self"]*sr
+    score = max(0.0, min(1.0, score))
+    return {"text_quality": tq, "context_density": cd, "self_rating": sr, "confidence": score}

--- a/symbolic-memory-core/utils/novelty.py
+++ b/symbolic-memory-core/utils/novelty.py
@@ -1,0 +1,69 @@
+from typing import Dict, List, Set
+from embeddings.embedder import embed_text, cosine_sparse
+from core.motif import SymbolicMemoryCore, MotifNode
+
+def _all_vectors(smc: SymbolicMemoryCore) -> List[Dict[str, float]]:
+    return [embed_text(m.content) for m in smc.list_motifs()]
+
+def _max_cosine(vec: Dict[str, float], corpus: List[Dict[str, float]]) -> float:
+    if not corpus:
+        return 0.0
+    best = 0.0
+    for v in corpus:
+        c = cosine_sparse(vec, v)
+        if c > best:
+            best = c
+    return best
+
+def semantic_novelty(smc: SymbolicMemoryCore, m: MotifNode) -> float:
+    """
+    1 - max cosine(new, any prior). Higher => more semantically novel.
+    """
+    new_vec = embed_text(m.content)
+    prior_vecs = _all_vectors(smc)
+    max_sim = _max_cosine(new_vec, prior_vecs)
+    return max(0.0, 1.0 - max_sim)
+
+def symbolic_novelty(smc: SymbolicMemoryCore, m: MotifNode) -> float:
+    """
+    Fraction of motif symbols that are new to the graph.
+    """
+    seen: Set[str] = set()
+    for x in smc.list_motifs():
+        for s in x.symbols:
+            seen.add(s.lower())
+    if not m.symbols:
+        return 0.0
+    new_syms = [s for s in m.symbols if s.lower() not in seen]
+    return len(new_syms) / float(len(m.symbols))
+
+def structural_novelty(smc: SymbolicMemoryCore, m: MotifNode, sim_threshold: float = 0.35) -> float:
+    """
+    Cheap bridge proxy: proportion of existing motifs similar to m above threshold.
+    Normalized to [0,1] by |V|.
+    """
+    V = len(smc.motifs)
+    if V == 0:
+        return 0.0
+    mv = embed_text(m.content)
+    hits = 0
+    for other in smc.list_motifs():
+        if other.id == m.id:
+            continue
+        if cosine_sparse(mv, embed_text(other.content)) >= sim_threshold:
+            hits += 1
+    return hits / float(V)
+
+def novelty_index(
+    smc: SymbolicMemoryCore,
+    m: MotifNode,
+    alpha: float = 0.5,   # semantic
+    beta: float = 0.2,    # symbolic
+    gamma: float = 0.3,   # structural
+    sim_threshold: float = 0.35
+) -> Dict[str, float]:
+    sem = semantic_novelty(smc, m)
+    sym = symbolic_novelty(smc, m)
+    stc = structural_novelty(smc, m, sim_threshold=sim_threshold)
+    score = alpha * sem + beta * sym + gamma * stc
+    return {"semantic": sem, "symbolic": sym, "structural": stc, "novelty_index": score}


### PR DESCRIPTION
## Summary
- add novelty metrics for semantic, symbolic, and structural aspects of motifs
- provide heuristic confidence scoring for generated text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a13a2c65448325b78402c5000a3de0