### PR TITLE
Add deterministic model stub and enable stubbed experiment runs

### DIFF
--- a/src/symbolic_recursion/core/model_stub.py
+++ b/src/symbolic_recursion/core/model_stub.py
@@ -1,0 +1,41 @@
+"""Deterministic model stub.
+
+This module supplies :func:`stub_response` – a tiny, reproducible
+stand‑in for a large language model.  It is useful for unit tests or
+offline experimentation where calling a real model would be costly or
+impossible.
+
+Example
+-------
+>>> from symbolic_recursion.core.model_stub import stub_response
+>>> stub_response("Hello world", model="demo")
+'[demo] Hello world'
+
+The optional ``timeout`` argument is ignored and is present only so that
+``stub_response`` matches the signature of
+:func:`symbolic_recursion.core.ollama_interface.query_ollama`.
+"""
+
+from typing import Optional
+
+
+def stub_response(prompt: str, model: str, timeout: Optional[int] = None) -> str:
+    """Return a reproducible response for ``prompt`` and ``model``.
+
+    Parameters
+    ----------
+    prompt:
+        Text prompt being "asked" to the stubbed model.
+    model:
+        Name of the model.  Included in the output so different models
+        produce distinguishable results.
+    timeout:
+        Ignored placeholder to mirror the interface of the real model
+        querying function.
+
+    Returns
+    -------
+    str
+        A deterministic string based solely on ``model`` and ``prompt``.
+    """
+    return f"[{model}] {prompt}"

--- a/src/symbolic_recursion/experiments/run_loop_novelty.py
+++ b/src/symbolic_recursion/experiments/run_loop_novelty.py
@@ -1,6 +1,6 @@
 import json, sys
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from symbolic_recursion.core.motif import SymbolicMemoryCore
 from symbolic_recursion.core.storage import load_motifs, save_motifs
@@ -34,9 +34,14 @@ def run(cfg_path: str):
     tm = ThreadManager(smc)
 
     if use_stub:
-        import symbolic_recursion.core as core.ollama_interface as oi
+        from symbolic_recursion.core import ollama_interface as oi
+        from symbolic_recursion.threads import manager as tmgr
         from symbolic_recursion.core.model_stub import stub_response
-        oi.query_ollama = lambda prompt, model=model, timeout=None: stub_response(prompt, model, timeout)
+
+        def _stub(prompt: str, model: str = model, timeout: Optional[int] = None) -> str:
+            return stub_response(prompt, model, timeout)
+
+        oi.query_ollama = tmgr.query_ollama = _stub
 
     state = _load_state()
 

--- a/src/symbolic_recursion/utils/metrics.py
+++ b/src/symbolic_recursion/utils/metrics.py
@@ -1,0 +1,40 @@
+"""Lightweight metric helpers used by the novelty loop.
+
+The real project computes a variety of graph and embedding statistics.
+For the purposes of unit tests and offline evaluation we provide very
+simple stand-ins that satisfy the interface required by
+``run_loop_novelty``.
+"""
+
+from typing import Dict, Any
+
+from symbolic_recursion.core.motif import SymbolicMemoryCore
+
+
+def graph_stats(smc: SymbolicMemoryCore) -> Dict[str, float]:
+    """Return trivial graph statistics for ``smc``.
+
+    The values are intentionally simplistic; they merely allow the
+    experiment script to run without depending on heavy graph libraries.
+    """
+    V = len(smc.motifs)
+    E = sum(len(m.references) for m in smc.motifs.values())
+    edge_density = (E / (V * (V - 1))) if V > 1 else 0.0
+    return {
+        "V": float(V),
+        "E": float(E),
+        "edge_density": edge_density,
+        "recurrence_rate": 0.0,
+        "lcc_fraction": 1.0 if V else 0.0,
+        "clustering_coeff": 0.0,
+        "avg_shortest_path": 0.0,
+    }
+
+
+def semantic_stats(smc: SymbolicMemoryCore, prev_centroid: Dict[str, float]) -> Dict[str, Any]:
+    """Return placeholder semantic statistics.
+
+    ``prev_centroid`` is ignored except for being echoed back so that the
+    calling code can persist state across runs.
+    """
+    return {"centroid_shift": 0.0, "cohesion": 0.0, "centroid": {}}


### PR DESCRIPTION
## Summary
- Provide `stub_response` helper in new `model_stub` module for deterministic, prompt-dependent replies
- Teach `run_loop_novelty` to use the stubbed model and add lightweight metrics helpers for offline runs

## Testing
- `python -m pytest`
- `PYTHONPATH=src python src/symbolic_recursion/experiments/run_loop_novelty.py /tmp/scenario.json`

------
https://chatgpt.com/codex/tasks/task_b_68a1466b0be88325951b4359ec9dec99