### PR TITLE
Add Chroma router option to CLI and novelty loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ python scripts/run_cli.py list
 python scripts/run_cli.py chat --prompt "Briefly outline Justice as a Gradient" --capture justice,gradient
 ```
 
+## Chroma Persistence
+
+SMC can persist vector search data using [Chroma](https://www.trychroma.com/).
+To enable it:
+
+1. Install the optional dependency (and SBERT for better embeddings):
+
+   ```bash
+   pip install chromadb sentence-transformers
+   ```
+
+2. (Optional) Index existing motifs into Chroma:
+
+   ```bash
+   python scripts/motif_to_chroma.py
+   ```
+
+3. Select the Chroma router via an environment variable or CLI flag:
+
+   ```bash
+   SMC_ROUTER=chroma python scripts/run_cli.py query --text "hello world"
+   # or
+   python scripts/run_cli.py --router chroma query --text "hello world"
+   ```
+
+Chroma data is stored under `data/chroma/`.
+
 ## Experiments
 
 The novelty harness generates motifs with an LLM and scores semantic novelty.

--- a/src/symbolic_recursion/experiments/run_loop_novelty.py
+++ b/src/symbolic_recursion/experiments/run_loop_novelty.py
@@ -36,7 +36,8 @@ def run(cfg_path: str):
     tm = ThreadManager(smc)
 
     router = None
-    if os.getenv("SMC_ROUTER", "").lower() == "vector":
+    rt = os.getenv("SMC_ROUTER", "").lower()
+    if rt == "vector":
         from symbolic_recursion.core.vector_router import VectorRouter
         try:
             from symbolic_recursion.embeddings.sbert import Embeddings
@@ -44,6 +45,15 @@ def run(cfg_path: str):
             router = VectorRouter(emb)
         except Exception:
             router = VectorRouter(None)
+        router.rebuild_from_smc(smc)
+    elif rt == "chroma":
+        from symbolic_recursion.core.chroma_router import ChromaRouter
+        try:
+            from symbolic_recursion.embeddings.sbert import Embeddings
+            emb = Embeddings()
+            router = ChromaRouter(emb)
+        except Exception:
+            router = ChromaRouter(None)
         router.rebuild_from_smc(smc)
 
     if use_stub:


### PR DESCRIPTION
## Summary
- allow `scripts/run_cli.py` to select VectorRouter or ChromaRouter via `--router` flag or `SMC_ROUTER` env var
- extend novelty loop to build a Chroma-backed router when configured
- document optional Chroma persistence setup in the README

## Testing
- `PYTHONPATH=src python scripts/run_cli.py --help`
- `PYTHONPATH=src python scripts/run_cli.py list`
- `python -m py_compile scripts/run_cli.py`
- `python -m py_compile src/symbolic_recursion/experiments/run_loop_novelty.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a175dd82c0832594bcd99eea8107fd