### PR TITLE
Unify router abstraction and add motif-aware retrieval boost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,5 @@ include-package-data = true
 
 [project.optional-dependencies]
 faiss = ["faiss-cpu"]
+chroma = ["chromadb>=0.5.0"]
+test = ["pytest>=8.0"]

--- a/src/symbolic_recursion/core/chroma_router.py
+++ b/src/symbolic_recursion/core/chroma_router.py
@@ -4,8 +4,12 @@ from typing import List, Tuple, Optional, Dict
 import threading
 import numpy as np
 
-import chromadb
-from chromadb.config import Settings
+try:
+    import chromadb
+    from chromadb.config import Settings
+except Exception:  # optional dependency
+    chromadb = None
+    Settings = None
 
 from symbolic_recursion.core.motif import SymbolicMemoryCore, MotifNode
 from symbolic_recursion.embeddings.sbert import Embeddings
@@ -57,6 +61,9 @@ class ChromaRouter:
         self.metric = metric
 
         self._lock = threading.RLock()
+        if chromadb is None or Settings is None:
+            raise RuntimeError("ChromaRouter requires optional dependency `chromadb`.")
+
         self._client = chromadb.PersistentClient(
             path=persist_dir,
             settings=Settings(allow_reset=False)
@@ -244,6 +251,10 @@ class ChromaRouter:
             if m is not None:
                 out.append((m, sim))
         return out
+
+    def persist(self) -> None:
+        """Chroma persistence is handled by the underlying persistent client."""
+        return None
 
     def suggest_for_motif(
         self, smc: SymbolicMemoryCore, motif_id: str, top_k: int = 5

--- a/src/symbolic_recursion/core/router_factory.py
+++ b/src/symbolic_recursion/core/router_factory.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+from symbolic_recursion.core.router_protocol import RouterProtocol
+from symbolic_recursion.core.vector_router import VectorRouter
+
+
+def make_router(kind: str | None = None) -> RouterProtocol:
+    router_kind = (kind or os.getenv("SMC_ROUTER", "vector")).lower()
+    if router_kind == "chroma":
+        from symbolic_recursion.core.chroma_router import ChromaRouter
+
+        return ChromaRouter()
+    return VectorRouter(None)

--- a/src/symbolic_recursion/core/router_protocol.py
+++ b/src/symbolic_recursion/core/router_protocol.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import List, Protocol, Tuple
+
+from symbolic_recursion.core.motif import MotifNode, SymbolicMemoryCore
+
+
+class RouterProtocol(Protocol):
+    """Minimal retrieval/index interface shared across router backends."""
+
+    def rebuild_from_smc(self, smc: SymbolicMemoryCore) -> None: ...
+
+    def search_text(self, text: str, top_k: int = 5) -> List[Tuple[MotifNode, float]]: ...
+
+    def add_motif(self, smc: SymbolicMemoryCore, m: MotifNode) -> None: ...
+
+    def persist(self) -> None: ...

--- a/src/symbolic_recursion/core/vector_router.py
+++ b/src/symbolic_recursion/core/vector_router.py
@@ -140,4 +140,7 @@ class VectorRouter:
             if len(out) >= top_k:
                 break
         return out
+    def persist(self) -> None:
+        """Compatibility no-op for in-memory routers."""
+        return None
 

--- a/src/symbolic_recursion/experiments/multi_run.py
+++ b/src/symbolic_recursion/experiments/multi_run.py
@@ -11,34 +11,7 @@ from symbolic_recursion.utils.novelty import novelty_index
 from symbolic_recursion.core.runtime_policy import Policy
 from symbolic_recursion.utils.context import render_context
 
-# Routers
-from symbolic_recursion.core.vector_router import VectorRouter
-try:
-    from symbolic_recursion.core.chroma_router import ChromaRouter  # persistent
-except Exception:
-    ChromaRouter = None  # type: ignore
-
-
-# -------- Router factory --------
-
-def _make_router(kind: str):
-    if kind.lower() == "chroma":
-        from symbolic_recursion.core.chroma_router import ChromaRouter
-        from symbolic_recursion.embeddings.sbert import Embeddings
-        return ChromaRouter(embeddings=Embeddings())
-    from symbolic_recursion.core.vector_router import VectorRouter
-    return VectorRouter(None)
-
-
-def _make_routerx(kind: str):
-    k = (kind or os.getenv("SMC_ROUTER", "vector")).lower()
-    if k == "chroma":
-        if ChromaRouter is None:
-            raise RuntimeError("ChromaRouter not available. `pip install chromadb` and ensure import path is correct.")
-        # Let ChromaRouter pick up your default Embeddings or legacy fallback internally
-        return ChromaRouter()
-    # In-memory fallback (SBERT+FAISS or numpy; legacy sparse if SBERT missing)
-    return VectorRouter(None)
+from symbolic_recursion.core.router_factory import make_router
 
 
 _router = None  # late-bound
@@ -47,7 +20,7 @@ _router = None  # late-bound
 def _ensure_router_built(smc: SymbolicMemoryCore, kind: str):
     global _router
     if _router is None:
-        _router = _make_router(kind)
+        _router = make_router(kind)
     _router.rebuild_from_smc(smc)
 
 

--- a/src/symbolic_recursion/experiments/run_loop_novelty.py
+++ b/src/symbolic_recursion/experiments/run_loop_novelty.py
@@ -37,23 +37,9 @@ def run(cfg_path: str):
 
     router = None
     rt = os.getenv("SMC_ROUTER", "").lower()
-    if rt == "vector":
-        from symbolic_recursion.core.vector_router import VectorRouter
-        try:
-            from symbolic_recursion.embeddings.sbert import Embeddings
-            emb = Embeddings()
-            router = VectorRouter(emb)
-        except Exception:
-            router = VectorRouter(None)
-        router.rebuild_from_smc(smc)
-    elif rt == "chroma":
-        from symbolic_recursion.core.chroma_router import ChromaRouter
-        try:
-            from symbolic_recursion.embeddings.sbert import Embeddings
-            emb = Embeddings()
-            router = ChromaRouter(emb)
-        except Exception:
-            router = ChromaRouter(None)
+    if rt:
+        from symbolic_recursion.core.router_factory import make_router
+        router = make_router(rt)
         router.rebuild_from_smc(smc)
 
     if use_stub:

--- a/src/symbolic_recursion/skills/knowledge_search.py
+++ b/src/symbolic_recursion/skills/knowledge_search.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Iterable, List, Optional, Set
 
-from symbolic_recursion.core.chroma_router import ChromaRouter
+from symbolic_recursion.core.router_protocol import RouterProtocol
 from symbolic_recursion.core.motif import SymbolicMemoryCore
 from symbolic_recursion.documents.indexer import DocumentIndexer
 from symbolic_recursion.documents.schema import SearchResult
@@ -11,17 +11,14 @@ from symbolic_recursion.documents.schema import SearchResult
 def knowledge_search(
     query: str,
     smc: SymbolicMemoryCore,
-    motif_router: ChromaRouter,
+    motif_router: RouterProtocol,
     document_indexer: Optional[DocumentIndexer] = None,
     top_k: int = 8,
     motif_k: Optional[int] = None,
     document_k: Optional[int] = None,
+    active_motif_ids: Optional[Iterable[str]] = None,
+    motif_boost_weight: float = 0.15,
 ) -> List[SearchResult]:
-    """Unified retrieval across motifs + document chunks.
-
-    Returns ranked `SearchResult` items with a stable shape suitable for skill
-    wrappers (e.g., OpenClaw-style documentation search endpoints).
-    """
     mk = motif_k or top_k
     dk = document_k or top_k
 
@@ -46,13 +43,23 @@ def knowledge_search(
 
     if document_indexer is not None:
         doc_hits = document_indexer.search(query, top_k=dk)
+        boost_symbols: Set[str] = set()
+        for mid in active_motif_ids or []:
+            motif = smc.get_motif(mid)
+            if motif is not None:
+                boost_symbols.update(s.lower() for s in motif.symbols)
         for chunk, score in doc_hits:
+            overlap = 0.0
+            if boost_symbols:
+                chunk_symbols = {t.lower() for t in chunk.tags}
+                overlap = len(boost_symbols & chunk_symbols) / max(1, len(chunk_symbols))
+            boosted_score = score + (motif_boost_weight * overlap)
             results.append(
                 SearchResult(
                     kind="document_chunk",
                     id=chunk.id,
                     content=chunk.content,
-                    score=score,
+                    score=boosted_score,
                     metadata={
                         "document_id": chunk.document_id,
                         "title": chunk.title,
@@ -60,6 +67,7 @@ def knowledge_search(
                         "chunk_index": chunk.chunk_index,
                         "tags": chunk.tags,
                         "updated_at": chunk.updated_at,
+                        "motif_overlap": overlap,
                     },
                 )
             )


### PR DESCRIPTION
### Motivation
- Unify duplicated router selection and lifecycle logic so retrieval clients depend on a single interface rather than backend-specific imports. 
- Make optional dependencies (Chroma) optional at runtime and avoid unconditional imports that break the fallback story. 
- Pull document retrieval toward the project vision by biasing document chunks toward motifs recently active in the graph (coherence-first). 
- Reduce dead/duplicated code in the experiments by centralizing router creation and selection.

### Description
- Add a `RouterProtocol` (`src/symbolic_recursion/core/router_protocol.py`) that defines `rebuild_from_smc`, `search_text`, `add_motif`, and `persist` as the minimal router API. 
- Add a `make_router` factory (`src/symbolic_recursion/core/router_factory.py`) and update `multi_run.py` and `run_loop_novelty.py` to use it instead of repeating backend selection logic. 
- Refactor `knowledge_search` to accept any `RouterProtocol` and add an optional motif-aware document boost using symbol overlap via `active_motif_ids` and `motif_boost_weight` (`src/symbolic_recursion/skills/knowledge_search.py`). 
- Gate `chromadb` imports in `ChromaRouter` and raise a clear error if the optional dependency is not installed, and add `persist()` compatibility no-ops to `VectorRouter` and `ChromaRouter` to standardize the interface (`src/symbolic_recursion/core/chroma_router.py`, `src/symbolic_recursion/core/vector_router.py`). 
- Update `pyproject.toml` to declare optional extras for `chroma` and `test` packages.

### Testing
- Ran a static compile pass with `python -m compileall src`, which completed successfully. 
- Executed a runtime smoke test `PYTHONPATH=src python -c "from symbolic_recursion.core.router_factory import make_router; print(type(make_router('vector')).__name__)"`, which returned `VectorRouter` successfully. 
- No automated `pytest` test suite was present to run in this change (added `test` optional dependency to `pyproject.toml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f70fd46e58832580c06b199bf0bedf)